### PR TITLE
RequestedDatetimeOverridesに関するOperationFilterのExtensionsを追加した

### DIFF
--- a/src/Swagger.Extensions.DependencyInjection/Extensions/OpenApiOperationExtensions.cs
+++ b/src/Swagger.Extensions.DependencyInjection/Extensions/OpenApiOperationExtensions.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.OpenApi.Any;
+using WebPack.CoreLib.HttpHeaders.RequestedDatetimeOverrides;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.OpenApi.Models;
+public static class OpenApiOperationExtensions {
+    public static void AddRequestedDatetimeOverrideOperationParameters(this OpenApiOperation operation, string timezoneId, string requestedDatetimeFormat) {
+        if (DefaultWebEnvironment.WebApps.IsNotDevelopment()) {
+            return;
+        }
+
+        operation.Parameters.Add(new OpenApiParameter {
+            Name = HeaderKeys.ForceOverrideRequestedDatetime,
+            In = ParameterLocation.Header,
+            AllowEmptyValue = true,
+            Required = false,
+            Schema = new OpenApiSchema { Type = "boolean" }
+        });
+
+        operation.Parameters.Add(new OpenApiParameter {
+            Name = HeaderKeys.OverrideRequestedDatetime,
+            In = ParameterLocation.Header,
+            AllowEmptyValue = true,
+            Required = false,
+            Schema = new OpenApiSchema { Type = "string", Example = new OpenApiString(TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, TimeZoneInfo.FindSystemTimeZoneById(timezoneId)).ToString(requestedDatetimeFormat)) }
+        });
+    }
+}

--- a/src/Swagger.Extensions.DependencyInjection/Swagger.Extensions.DependencyInjection.csproj
+++ b/src/Swagger.Extensions.DependencyInjection/Swagger.Extensions.DependencyInjection.csproj
@@ -1,16 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <Version>1.3.4.1</Version>
+    <Version>1.3.5.1</Version>
     <Authors>Vitae</Authors>
     <Description>For ASP.NET Core Swagger Extension;
 
 Include Default Builder;</Description>
     <PackageProjectUrl>https://github.com/CreatioVitae/WebApiPack</PackageProjectUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageReleaseNotes>upgrade package.</PackageReleaseNotes>
+    <PackageReleaseNotes>add OpenApiOperationExtensions.</PackageReleaseNotes>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -22,6 +21,6 @@ Include Default Builder;</Description>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-    <PackageReference Include="WebPack.Identity.CoreLib" Version="0.7.4" />
+    <PackageReference Include="WebPack.Identity.CoreLib" Version="0.7.5" />
   </ItemGroup>
 </Project>

--- a/src/WebApiPack/WebApiPack.csproj
+++ b/src/WebApiPack/WebApiPack.csproj
@@ -6,7 +6,7 @@
     <ApplicationIcon />
     <OutputType>Library</OutputType>
     <StartupObject />
-    <Version>0.10.2</Version>
+    <Version>0.11.1</Version>
     <Authors>Vitae</Authors>
     <PackageProjectUrl>https://github.com/CreatioVitae/WebApiPack</PackageProjectUrl>
     <Description>For ASP.NET Core REST API Pack;
@@ -28,6 +28,6 @@ Include Default Builder;</Description>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="WebPack.CoreLib" Version="0.10.2" />
+    <PackageReference Include="WebPack.CoreLib" Version="0.11.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## 新機能

[RequestedDatetimeOverridesに関するOperationFilterのExtensionsを追加した](https://github.com/CreatioVitae/WebApiPack/pull/55)

## 不具合修正

なし

## 開発者向け

なし